### PR TITLE
Replace deprecated gulp-util w/ plugin-error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
-const gutil = require('gulp-util'),
-    PluginError = gutil.PluginError,
+const PluginError = require('plugin-error'),
     es = require('event-stream'),
     through = require('through2'),
     compodocModule = require('@compodoc/compodoc'),

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@compodoc/compodoc": "^1.0.3",
     "event-stream": "^3.3.4",
-    "gulp-util": "^3.0.7",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Running `yarn` results in this warning

```
warning @compodoc/gulp-compodoc > gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
```

This PR uses the drop in replacement suggested in the article.